### PR TITLE
Add support for WindowsAzure.Storage 7.0.0

### DIFF
--- a/src/ResourceManagement/HDInsightJob/HDInsightJob/Microsoft.Azure.Management.HDInsight.Job.nuspec
+++ b/src/ResourceManagement/HDInsightJob/HDInsightJob/Microsoft.Azure.Management.HDInsight.Job.nuspec
@@ -84,7 +84,7 @@ The methods “GetJobOutput”(+Async) and “GetJobErrorLogsAsync”(+Async) no
     </references>
     <dependencies>
       <dependency id="Microsoft.Azure.Common" version="[2.1.0,3.0)" />
-      <dependency id="WindowsAzure.Storage" version="[6.0.0,7.0)" />
+      <dependency id="WindowsAzure.Storage" version="[6.0.0,8.0)" />
     </dependencies>
   </metadata>
   <files>


### PR DESCRIPTION
Attempting to gather dependency information for package 'WindowsAzure.Storage.7.0.0' with respect to project 'MyHdiProject', targeting '.NETFramework,Version=v4.5.2'
Attempting to resolve dependencies for package 'WindowsAzure.Storage.7.0.0' with DependencyBehavior 'Lowest'
Unable to resolve dependencies. 'WindowsAzure.Storage 7.0.0' is not compatible with 'Microsoft.Azure.Management.HDInsight.Job 2.0.2 constraint: WindowsAzure.Storage (>= 6.0.0 && < 7.0.0)'.